### PR TITLE
Valid library.properties category value

### DIFF
--- a/Plotter/library.properties
+++ b/Plotter/library.properties
@@ -4,6 +4,6 @@ author=Devin Conley <devinconley@jhu.edu>
 maintainer=Devin Conley <devinconley@jhu.edu>
 sentence=an Arduino library for easy plotting using Processing via serial communication.
 paragraph=Supports multi-variable plots against time as well as 2D plotting of an X vs Y variable. Multiple graphs can be displayed at once, will all formatting and scaling handled automatically. Various listener options are provided, including stand-alone options so that the Processing software does NOT need to be downloaded. The listener requires no modification; just start the program.
-category=Graphing Data
+category=Data Processing
 url=https://github.com/devinconley/ArduinoPlotter
 architectures=*


### PR DESCRIPTION
Fixes the `WARNING: Category 'Graphing Data' in library Plotter is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7. If you prefer a different category I'm happy to change it to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.